### PR TITLE
Remove group from top-level fields of custom resource provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,7 @@ const cr = new Operator();
 
 cr.addProvider({
   kind: 'WebService',
-  apiVersion: 'v1',
-  group: 'org.cdk8s.samples',
+  apiVersion: 'samples.cdk8s.org/v1alpha1',
   // schema: ...
   handler: {
     apply: (scope, name, spec) => new WebService(scope, name, spec),
@@ -41,9 +40,8 @@ To use this operator, create an `input.json` file, e.g:
 
 ```json
 {
-  "apiVersion": "v1",
+  "apiVersion": "samples.cdk8s.org/v1alpha1",
   "kind": "WebService",
-  "group": "org.cdk8s.samples",
   "metadata": {
     "name": "my-web-service"
   },

--- a/src/operator.ts
+++ b/src/operator.ts
@@ -13,7 +13,6 @@ export interface ICustomResourceProviderHandler {
 }
 
 export interface CustomResourceProvider {
-  readonly group: string;
   readonly kind: string;
 
   /**
@@ -59,7 +58,7 @@ export class Operator extends App {
 
     const chart = new Chart(this, name, { namespace });
 
-    console.error(`Synthesizing ${input.group}.${input.kind}/${input.apiVersion}`);
+    console.error(`Synthesizing ${input.kind}.${input.apiVersion}`);
     provider.handler.apply(chart, name, spec);
 
     super.synth();
@@ -70,8 +69,8 @@ export class Operator extends App {
     }
   }
 
-  private findProvider(input: { group: string, kind: string, apiVersion: string }) {
-    const { apiVersion, kind, group } = input;
+  private findProvider(input: { kind: string, apiVersion: string }) {
+    const { apiVersion, kind } = input;
 
     if (!apiVersion) {
       throw new Error('"apiVersion" is required');
@@ -81,17 +80,13 @@ export class Operator extends App {
       throw new Error('"kind" is required');
     }
 
-    if (!group) {
-      throw new Error('"group" is required');
-    }
-
     for (const p of this.providers) {
-      if (p.apiVersion === apiVersion && p.kind === kind && p.group === group) {
+      if (p.apiVersion === apiVersion && p.kind === kind) {
         return p;
       }
     }
 
-    throw new Error(`No custom resource provider found for ${group}.${kind}/${apiVersion}`);
+    throw new Error(`No custom resource provider found for ${kind}.${apiVersion}`);
   }
 }
 

--- a/src/web-service-operator.ts
+++ b/src/web-service-operator.ts
@@ -5,8 +5,7 @@ const cr = new Operator();
 
 cr.addProvider({
   kind: 'WebService',
-  apiVersion: 'v1',
-  group: 'org.cdk8s.samples',
+  apiVersion: 'samples.cdk8s.org/v1alpha1',
   // schema: ...
   handler: {
     apply: (scope, name, spec) => new WebService(scope, name, spec),

--- a/test/input.json
+++ b/test/input.json
@@ -1,7 +1,6 @@
 {
-  "apiVersion": "v1",
+  "apiVersion": "samples.cdk8s.org/v1alpha1",
   "kind": "WebService",
-  "group": "org.cdk8s.samples",
   "metadata": {
     "name": "my-web-service"
   },


### PR DESCRIPTION
*Description of changes:*

Standard Kubernetes objects do not have `group` as top-level field, it's covered by `apiVersion` in the form of `group/version`, for example `apiVersion: sample.cdk8s.org/v1alpha1`. But current implementation assumes they do and this causes problems when working with native objects.

This PR removes `group` field from top level field assumptions and updates the example to work without that field. Also `v1` is changed to `v1alpha1` since that's usually the level CRDs start their lifecycle but that's just a string in this context, doesn't really affect functionality.

Tested with the following commands:
```bash
$ yarn run compile
yarn run v1.22.5
tsc
✨  Done in 3.10s.
```
```
$ node lib/web-service-operator.js < test/input.json
Synthesizing WebService.samples.cdk8s.org/v1alpha1
apiVersion: apps/v1
kind: Deployment
metadata:
  name: my-web-service-deployment-pod-b9bf8233
spec:
  replicas: 1
  selector:
    matchLabels:
      cdk8s.deployment: mywebservicedeployment25C8720D
  template:
    metadata:
      labels:
        cdk8s.deployment: mywebservicedeployment25C8720D
    spec:
      containers:
        - env: []
          image: paulbouwer/hello-kubernetes
          name: main
          ports:
            - containerPort: 8080
          volumeMounts: []
      volumes: []
---
apiVersion: v1
kind: Service
metadata:
  name: my-web-service-deployment-service-pod-e97cbd24
spec:
  externalIPs: []
  ports:
    - port: 80
      targetPort: 8080
  selector:
    cdk8s.deployment: mywebservicedeployment25C8720D
  type: ClusterIP
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
